### PR TITLE
Fix .tsbuildinfo file not being ignored

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsc-ls",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "packageManager": "yarn@3.2.1",
   "license": "MIT",
   "main": "./dist/compile.js",

--- a/src/builder-host.ts
+++ b/src/builder-host.ts
@@ -29,7 +29,7 @@ export const createBuilderHost = ({
       return ts.sys.readFile(path);
     }
 
-    if (path === services.tsConfig.options.tsBuildInfoFile) {
+    if (path.includes('.tsbuildinfo')) {
       return ts.sys.readFile(path);
     }
 


### PR DESCRIPTION
Fix .tsbuildinfo file not being ignored like it should.

Use of `path.includes('.tsbuildinfo')` is not restrictive enough, need change for later.